### PR TITLE
[PUX-2806] Add additional configuration

### DIFF
--- a/Objective-C Bridge/TrueLayerAdditionalConfigurationKey.swift
+++ b/Objective-C Bridge/TrueLayerAdditionalConfigurationKey.swift
@@ -4,17 +4,13 @@ import TrueLayerSDK
 /// These keys are returned from the TrueLayer SDK, ensuring they match what is expected.
 @objc
 public class TrueLayerAdditionalConfigurationKey: NSObject {
-  /// The type of integration with the TrueLayer SDK, e.g. native or React Native.
+  /// The type of integration with the TrueLayer SDK, e.g. React Native.
   @objc
-  public static var integrationType: String {
-    TrueLayer.Payments.AdditionalConfiguration.Key.integrationType.rawValue
-  }
+  public static var integrationType = "integrationType"
   
   /// The version of the integration, if necessary.
   ///
   /// This should be included if the `integrationType` is not native.
   @objc
-  public static var integrationVersion: String {
-    TrueLayer.Payments.AdditionalConfiguration.Key.integrationVersion.rawValue
-  }
+  public static var integrationVersion = "integrationVersion"
 }

--- a/Objective-C Bridge/TrueLayerAdditionalConfigurationKey.swift
+++ b/Objective-C Bridge/TrueLayerAdditionalConfigurationKey.swift
@@ -1,0 +1,20 @@
+import TrueLayerSDK
+
+/// The  keys to use when customizing the additional configuration dictionary for the TrueLayerSDK.
+/// These keys are returned from the TrueLayer SDK, ensuring they match what is expected.
+@objc
+public class TrueLayerAdditionalConfigurationKey: NSObject {
+  /// The type of integration with the TrueLayer SDK, e.g. native or React Native.
+  @objc
+  public static var integrationType: String {
+    TrueLayer.Payments.AdditionalConfiguration.Key.integrationType.rawValue
+  }
+  
+  /// The version of the integration, if necessary.
+  ///
+  /// This should be included if the `integrationType` is not native.
+  @objc
+  public static var integrationVersion: String {
+    TrueLayer.Payments.AdditionalConfiguration.Key.integrationVersion.rawValue
+  }
+}

--- a/Objective-C Bridge/TrueLayerBridge.swift
+++ b/Objective-C Bridge/TrueLayerBridge.swift
@@ -24,7 +24,8 @@ public class TrueLayerBridge: NSObject {
     additionalConfiguration: [String: String]
   ) {
     let trueLayerEnvironment: TrueLayer.Environment
-
+    var configuration = additionalConfiguration
+    
     switch environment {
       case .sandbox:
         trueLayerEnvironment = .sandbox
@@ -34,13 +35,10 @@ public class TrueLayerBridge: NSObject {
     }
 
     if additionalConfiguration[TrueLayerAdditionalConfigurationKey.integrationType] == nil {
-      additionalConfiguration[TrueLayerAdditionalConfigurationKey.integrationType] = "ObjectiveC"
+      configuration[TrueLayerAdditionalConfigurationKey.integrationType] = "ObjectiveC"
     }
 
-    TrueLayer.Payments.manager.configure(
-      environment: trueLayerEnvironment,
-      additionalConfiguration: additionalConfiguration
-    )
+    TrueLayer.Payments.manager.configure(environment: trueLayerEnvironment, additionalConfiguration: configuration)
   }
     
   /// Presents the SDK in the app to carry out a payment.

--- a/Objective-C Bridge/TrueLayerBridge.swift
+++ b/Objective-C Bridge/TrueLayerBridge.swift
@@ -8,6 +8,18 @@ public class TrueLayerBridge: NSObject {
   /// - Parameter environment: The environment to set up the SDK with.
   @objc
   public static func configure(with environment: TrueLayerEnvironment) {
+    configure(with: environment, additionalConfiguration: [:])
+  }
+    
+  /// Configures and sets up the SDK for a given environment.
+  /// - Parameters:
+  ///   - environment: The environment to set up the SDK with.
+  ///   - additionalConfiguration: A dictionary with extra information to configure the SDK.
+  @objc
+  public static func configure(
+    with environment: TrueLayerEnvironment,
+    additionalConfiguration: [String: String]
+  ) {
     let trueLayerEnvironment: TrueLayer.Environment
 
     switch environment {
@@ -18,7 +30,10 @@ public class TrueLayerBridge: NSObject {
         trueLayerEnvironment = .production
     }
 
-    TrueLayer.Payments.manager.configure(environment: trueLayerEnvironment)
+    TrueLayer.Payments.manager.configure(
+      environment: trueLayerEnvironment,
+      additionalConfiguration: additionalConfiguration
+    )
   }
     
   /// Presents the SDK in the app to carry out a payment.

--- a/Objective-C Bridge/TrueLayerBridge.swift
+++ b/Objective-C Bridge/TrueLayerBridge.swift
@@ -8,7 +8,10 @@ public class TrueLayerBridge: NSObject {
   /// - Parameter environment: The environment to set up the SDK with.
   @objc
   public static func configure(with environment: TrueLayerEnvironment) {
-    configure(with: environment, additionalConfiguration: [:])
+    configure(
+      with: environment, 
+      additionalConfiguration: [TrueLayerAdditionalConfigurationKey.integrationType: "ObjectiveC"]
+    )
   }
     
   /// Configures and sets up the SDK for a given environment.
@@ -28,6 +31,10 @@ public class TrueLayerBridge: NSObject {
 
       case .production:
         trueLayerEnvironment = .production
+    }
+
+    if additionalConfiguration[TrueLayerAdditionalConfigurationKey.integrationType] == nil {
+      additionalConfiguration[TrueLayerAdditionalConfigurationKey.integrationType] = "ObjectiveC"
     }
 
     TrueLayer.Payments.manager.configure(

--- a/Objective-C Bridge/TrueLayerObjectiveCAdditionalConfigurationKey.h
+++ b/Objective-C Bridge/TrueLayerObjectiveCAdditionalConfigurationKey.h
@@ -1,0 +1,15 @@
+#ifndef TrueLayerObjectiveCAdditionalConfigurationKey_h
+#define TrueLayerObjectiveCAdditionalConfigurationKey_h
+
+@interface TrueLayerObjectiveCAdditionalConfigurationKey: NSObject
+/// The type of integration with the TrueLayer SDK, e.g. native or React Native.
++(NSString *)integrationType;
+
+/// The version of the integration, if necessary.
+///
+/// This should be included if the `integrationType` is not native.
++(NSString *)integrationVersion;
+
+@end
+
+#endif /* TrueLayerObjectiveCAdditionalConfigurationKey_h */

--- a/Objective-C Bridge/TrueLayerObjectiveCAdditionalConfigurationKey.m
+++ b/Objective-C Bridge/TrueLayerObjectiveCAdditionalConfigurationKey.m
@@ -1,0 +1,15 @@
+#import <Foundation/Foundation.h>
+#import "TrueLayerObjectiveCAdditionalConfigurationKey.h"
+#import "TrueLayerPaymentsSDK-Swift.h"
+
+@implementation TrueLayerObjectiveCAdditionalConfigurationKey
+
++ (NSString *)integrationType {
+  return [TrueLayerAdditionalConfigurationKey integrationType];
+}
+
++ (NSString *)integrationVersion {
+  return [TrueLayerAdditionalConfigurationKey integrationVersion];
+}
+
+@end

--- a/Objective-C Bridge/TrueLayerObjectiveCBridge.h
+++ b/Objective-C Bridge/TrueLayerObjectiveCBridge.h
@@ -16,8 +16,14 @@
 /// Configures and sets up the SDK for a given environment.
 /// - Parameters:
 ///   - environment: The environment to set up the SDK with.
-///   - error: An error that occurs during configuration, for example if the environment is not valid.
 +(void)configureWith:(TrueLayerObjectiveCEnvironment)environment;
+
+/// Configures and sets up the SDK for a given environment.
+/// - Parameters:
+///   - environment: The environment to set up the SDK with.
+///   - additionalConfiguration: A dictionary with extra information to configure the SDK.
++(void)configureWith:(TrueLayerObjectiveCEnvironment)environment
+additionalConfiguration:(NSDictionary * _Nonnull)additionalConfiguration;
 
 // MARK: - Single Payment
 

--- a/Objective-C Bridge/TrueLayerObjectiveCBridge.m
+++ b/Objective-C Bridge/TrueLayerObjectiveCBridge.m
@@ -5,8 +5,13 @@
 @implementation TrueLayerObjectiveCBridge
 
 + (void)configureWith:(TrueLayerObjectiveCEnvironment)environment {
+  [TrueLayerObjectiveCBridge configureWith:environment
+                   additionalConfiguration:[NSDictionary dictionary]];
+}
+
++ (void)configureWith:(TrueLayerObjectiveCEnvironment)environment additionalConfiguration:(NSDictionary *)additionalConfiguration {
   TrueLayerEnvironment trueLayerEnvironment;
-  
+
   switch (environment) {
     case TrueLayerObjectiveCEnvironmentSandbox:
       trueLayerEnvironment = TrueLayerEnvironmentSandbox;
@@ -16,8 +21,9 @@
       trueLayerEnvironment = TrueLayerEnvironmentProduction;
       break;
   }
-  
-  [TrueLayerBridge configureWith:trueLayerEnvironment];
+
+  [TrueLayerBridge configureWith:trueLayerEnvironment
+         additionalConfiguration:additionalConfiguration];
 }
 
 + (void)processSinglePaymentWithContext:(TrueLayerSinglePaymentContext * _Nonnull)context


### PR DESCRIPTION
- Adds support for the passing an additional configuration dictionary via objective-c.
- Adds the additional configuration keys in an objC equivalent